### PR TITLE
"django.conf.urls.defaults" is deprecated in Django 1.4, removed in Djan...

### DIFF
--- a/uptimerobot/urls.py
+++ b/uptimerobot/urls.py
@@ -1,5 +1,8 @@
 """URLs for the uptimerobot app."""
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
  
 
 


### PR DESCRIPTION
"django.conf.urls.defaults" is deprecated in Django 1.4, removed in Django 1.6
